### PR TITLE
Adicionado console.count() no lugar de incremento

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,7 +11,6 @@ server.use(express.json());
  * pode receber adições ou exclusões mesmo sendo
  * uma constante.
  */
-let numberOfRequests = 0;
 const projects = [];
 
 /**
@@ -34,7 +33,7 @@ function checkProjectExists(req, res, next) {
 function logRequests(req, res, next) {
   numberOfRequests++;
 
-  console.log(`Número de requisições: ${numberOfRequests}`);
+  console.count("Número de requisições");
 
   return next();
 }

--- a/index.js
+++ b/index.js
@@ -31,7 +31,6 @@ function checkProjectExists(req, res, next) {
  * Middleware que dá log no número de requisições
  */
 function logRequests(req, res, next) {
-  numberOfRequests++;
 
   console.count("Número de requisições");
 


### PR DESCRIPTION
No lugar de criar uma variável, incrementar e dar console.log(), é possível utilizar apenas console.count("nome do contador").